### PR TITLE
SRE-228 Add step to generate secret and config file for flutter lint

### DIFF
--- a/.github/workflows/dime-app.yml
+++ b/.github/workflows/dime-app.yml
@@ -73,6 +73,24 @@ jobs:
           go_version: ${{ inputs.go-version }}
           node_version: ${{ inputs.node-version }}
           gh_access_token: ${{ secrets.gh_access_token }}
+      - name: Generate environment secret file
+        run: |
+          JWT=$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)
+          echo "{\"role\":\"kubernetes-actions-runner\",\"jwt\":\"$JWT\"}" > payload.json
+          TOKEN=$(curl -d @payload.json https://vault.mydime.tech/v1/auth/kubernetes/actions-runner/main/login | jq -r '.auth.client_token')
+          DATA=$(curl -H "X-VAULT-TOKEN:$TOKEN" https:/vault.mydime.tech/v1/secrets/data/services/dime-app/testing)
+
+          export DIRECTUS_ACCESS_TOKEN=$(echo $DATA | jq -r ".data.data.DIRECTUS_ACCESS_TOKEN")
+          export PASSWORD_HASHING_SALT=$(echo $DATA | jq -r ".data.data.PASSWORD_HASHING_SALT")
+          export SECURE_ED25519_PUBLIC_KEY=$(echo $DATA | jq -r ".data.data.SECURE_ED25519_PUBLIC_KEY")
+          export SECURE_RSA_PUBLIC_KEY=$(echo $DATA | jq -r ".data.data.SECURE_RSA_PUBLIC_KEY")
+          export SIGN_IN_RSA_PUBLIC_KEY=$(echo $DATA | jq -r ".data.data.SIGN_IN_RSA_PUBLIC_KEY")
+          export PATH=/opt/flutter/bin:$PATH
+
+          curl -L https://github.com/a8m/envsubst/releases/download/v1.2.0/envsubst-`uname -s`-`uname -m` -o envsubst
+          chmod +x envsubst
+          ./envsubst < environment_secret_template.yaml > environment_secret_sit.yaml
+          make gen-config-sit
       - uses: kkp-dfs/dime-github-actions-workflows/lint@main
         with:
           language: flutter


### PR DESCRIPTION
Flutter lint fails to find URI and EnvironmentSecret class when run analyze. Seems like it requires all the config file to run analyze.
This PR adds a step to generate config and secret file using SIT environment to run analze (lint).