### PR TITLE
Revert "Added steps for flutter unittest coverage"

### DIFF
--- a/unit-test/action.yml
+++ b/unit-test/action.yml
@@ -54,9 +54,7 @@ runs:
     - name: Run flutter unit test
       if: ${{ inputs.language == 'flutter' }}
       shell: bash
-      run: |
-        make test
-        make lcov-remove-coverage
+      run: make test
 
     - id: fail_message
       if: ${{ failure() }}


### PR DESCRIPTION
Reverts kkp-dfs/dime-github-actions-workflows#93
Due to unsuccessful ci on `dime-app`
https://github.com/kkp-dfs/dime-app/runs/6919881849?check_suite_focus=true